### PR TITLE
Change target (spot) decimal attributes to float fix

### DIFF
--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -4,9 +4,9 @@
 #
 #  id         :integer          not null, primary key
 #  title      :string           not null
-#  latitude   :decimal(, )      not null
-#  longitude  :decimal(, )      not null
-#  radius     :decimal(, )      not null
+#  latitude   :float            not null
+#  longitude  :float            not null
+#  radius     :float            not null
 #  user_id    :integer
 #  topic_id   :integer
 #  created_at :datetime         not null

--- a/db/migrate/20181011150040_change_spot_geo_attrs.rb
+++ b/db/migrate/20181011150040_change_spot_geo_attrs.rb
@@ -1,0 +1,7 @@
+class ChangeSpotGeoAttrs < ActiveRecord::Migration[5.2]
+  def change
+    change_column :spots, :latitude, :float
+    change_column :spots, :longitude, :float
+    change_column :spots, :radius, :float
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,16 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_04_133147) do
+ActiveRecord::Schema.define(version: 2018_10_11_150040) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "spots", force: :cascade do |t|
     t.string "title", null: false
-    t.decimal "latitude", null: false
-    t.decimal "longitude", null: false
-    t.decimal "radius", null: false
+    t.float "latitude", null: false
+    t.float "longitude", null: false
+    t.float "radius", null: false
     t.bigint "user_id"
     t.bigint "topic_id"
     t.datetime "created_at", null: false

--- a/spec/factories/spots.rb
+++ b/spec/factories/spots.rb
@@ -4,9 +4,9 @@
 #
 #  id         :integer          not null, primary key
 #  title      :string           not null
-#  latitude   :decimal(, )      not null
-#  longitude  :decimal(, )      not null
-#  radius     :decimal(, )      not null
+#  latitude   :float            not null
+#  longitude  :float            not null
+#  radius     :float            not null
 #  user_id    :integer
 #  topic_id   :integer
 #  created_at :datetime         not null

--- a/spec/models/spot_spec.rb
+++ b/spec/models/spot_spec.rb
@@ -4,9 +4,9 @@
 #
 #  id         :integer          not null, primary key
 #  title      :string           not null
-#  latitude   :decimal(, )      not null
-#  longitude  :decimal(, )      not null
-#  radius     :decimal(, )      not null
+#  latitude   :float            not null
+#  longitude  :float            not null
+#  radius     :float            not null
 #  user_id    :integer
 #  topic_id   :integer
 #  created_at :datetime         not null

--- a/spec/requests/api/v1/spots/create_spec.rb
+++ b/spec/requests/api/v1/spots/create_spec.rb
@@ -40,9 +40,9 @@ describe 'POST api/v1/spots', type: :request do
       post api_v1_spots_path, params: params, headers: auth_headers, as: :json
       expect(json[:spot]).to include_json(
         id: spot.id,
-        latitude: format('%.6g', format('%.6f', spot.latitude)),
-        longitude: format('%.6g', format('%.6f', spot.longitude)),
-        radius: format('%.1f', spot.radius),
+        latitude: spot.latitude,
+        longitude: spot.longitude,
+        radius: spot.radius,
         topic_id: spot.topic_id
       )
     end

--- a/spec/requests/api/v1/spots/index_spec.rb
+++ b/spec/requests/api/v1/spots/index_spec.rb
@@ -11,9 +11,9 @@ describe 'GET api/v1/spots', type: :request do
     spots.each do |spot|
       expect(json).to include_json(
         spots: UnorderedArray(id: spot.id, title: spot.title,
-                              latitude: format('%.6g', format('%.6f', spot.latitude)),
-                              longitude: format('%.6g', format('%.6f', spot.longitude)),
-                              radius: format('%.1f', spot.radius),
+                              latitude: spot.latitude,
+                              longitude: spot.longitude,
+                              radius: spot.radius,
                               topic_id: spot.topic_id)
       )
     end


### PR DESCRIPTION
Changed target decimal type attributes to float in order to avoid unnecessary formatting.