### PR TITLE
Add support for uploading base64 images for user's avatars

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ gem 'devise_token_auth', '~> 0.1.43'
 gem 'geokit-rails', '~> 2.3', '>= 2.3.1'
 gem 'koala', '~> 3.0'
 gem 'carrierwave', '~> 1.2', '>= 1.2.3'
+gem 'carrierwave-base64', '~> 2.7'
 gem 'mini_magick', '~> 4.9', '>= 4.9.2'
 gem 'fog-aws', '~> 3.3'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,6 +64,9 @@ GEM
       activemodel (>= 4.0.0)
       activesupport (>= 4.0.0)
       mime-types (>= 1.16)
+    carrierwave-base64 (2.7.0)
+      carrierwave (>= 0.8.0)
+      mime-types (~> 3.0)
     code_analyzer (0.4.8)
       sexp_processor
     codeclimate-engine-rb (0.4.1)
@@ -309,6 +312,7 @@ DEPENDENCIES
   bootsnap (>= 1.1.0)
   byebug
   carrierwave (~> 1.2, >= 1.2.3)
+  carrierwave-base64 (~> 2.7)
   database_cleaner (~> 1.4.1)
   devise (~> 4.4.3)
   devise_token_auth (~> 0.1.43)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -40,7 +40,7 @@
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
-  mount_uploader :avatar, AvatarUploader
+  mount_base64_uploader :avatar, AvatarUploader
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
   include DeviseTokenAuth::Concerns::User

--- a/app/uploaders/avatar_uploader.rb
+++ b/app/uploaders/avatar_uploader.rb
@@ -5,11 +5,6 @@ class AvatarUploader < CarrierWave::Uploader::Base
     "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
   end
 
-  def default_url(*)
-    ActionController::Base.helpers.asset_path('fallback/' + [version_name, 'default-avatar.png']
-      .compact.join('_'))
-  end
-
   version :thumb do
     process resize_to_fit: [64, 64]
   end

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -1,5 +1,5 @@
 CarrierWave.configure do |config|
-  if Rails.env.test?
+  if Rails.env.test? || Rails.env.development? || Rails.env.cucumber?
     config.storage = :file
     config.enable_processing = false
   else

--- a/spec/requests/api/v1/users/update_spec.rb
+++ b/spec/requests/api/v1/users/update_spec.rb
@@ -5,6 +5,17 @@ describe 'PUT api/v1/users/:id', type: :request do
   let(:new_email)         { 'test2@test.com' }
   let(:new_name)          { 'Test2' }
   let(:new_gender)        { 'female' }
+  let(:image_data) do
+    Base64.encode64(File.open(
+                      File.join(
+                        Rails.root, 'spec/assets/default-avatar.png'
+                      ), &:read
+                    ))
+  end
+
+  let(:image)             { "data:image/png;base64,#{image_data}" }
+  let(:image_url)         { "/uploads/user/avatar/#{user.id}/" }
+  let(:image_filename)    { 'avatar.png' }
 
   before do
     put api_v1_user_path(user), params: params, headers: auth_headers, as: :json
@@ -13,7 +24,12 @@ describe 'PUT api/v1/users/:id', type: :request do
   context 'with valid params' do
     let(:params) do
       {
-        user: { email: new_email, name: new_name, gender: new_gender }
+        user: {
+          email: new_email,
+          name: new_name,
+          gender: new_gender,
+          avatar: image
+        }
       }
     end
 
@@ -26,6 +42,7 @@ describe 'PUT api/v1/users/:id', type: :request do
       expect(user.email).to eq(new_email)
       expect(user.name).to eq(new_name)
       expect(user.gender).to eq(new_gender)
+      expect(user.avatar.url).to eq(image_url + image_filename)
     end
 
     it 'returns the user' do
@@ -33,7 +50,16 @@ describe 'PUT api/v1/users/:id', type: :request do
         id: user.id,
         email: new_email,
         name: new_name,
-        gender: new_gender
+        gender: new_gender,
+        avatar: {
+          url: image_url + image_filename,
+          thumb: {
+            url: image_url + 'thumb_' + image_filename
+          },
+          normal: {
+            url: image_url + 'normal_' + image_filename
+          }
+        }
       )
     end
   end


### PR DESCRIPTION
**Trello board reference:**

- https://trello.com/c/jx6HB7Ia

**Description:**
- Allow users to upload base64 avatar images.