### PR TITLE
Fix notifications service call

### DIFF
--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -58,13 +58,13 @@ class Spot < ApplicationRecord
   end
 
   def notify(match)
-    return unless match.second_user_push_token
+    return unless match.second_user_push_token.any?
     data = {
       name: match.second_user_name,
       avatar: match.second_user_avatar.url,
       match_id: match.id
     }
     NotificationService.new.notify(match.second_user_push_token,
-                                   t('api.notifications.new_match'), data)
+                                   I18n.t('api.notifications.new_match'), data)
   end
 end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     password_confirmation { 'password' }
     name                  { Faker::Name.name }
     gender                { User.genders.keys.sample }
+    push_token            { ['123a4567-8a9a-12aa-a34a-5aa67a89aaaa'] }
 
     factory :user_with_conversations do
       transient do


### PR DESCRIPTION
**Trello board reference:**

- https://trello.com/c/fScuTPQJ

**Description:**
- Fix for [this PR](https://github.com/sebastiancaraballo/target/pull/21).
- User's push_token attribute is an array. In order to send a notification, it is required that this array has at least one id.